### PR TITLE
Switch the order: <pre><code> instead of <code><pre>

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ As a concrete example, the difference between the default exporter and `slimhtml
 
 #### source code
 
-    #+BEGIN_SRC javascript                     # <code class="javascript">
-      code                                     # <pre>code</pre>
-    #+END_SRC                                  # </code>
+    #+BEGIN_SRC javascript                     # <pre>
+      code                                     # <code class="javascript">code</code>
+    #+END_SRC                                  # </pre>
 
 
 ### template

--- a/ox-slimhtml-tests.el
+++ b/ox-slimhtml-tests.el
@@ -114,9 +114,9 @@
                     "#+attr_html: :type text/css\n#+BEGIN_STYLE\n#id{color:#f73;}\n#+END_STYLE"))
 
 (ert-deftest ox-slimhtml-src-block ()
-  (should-render-as "<code class=\"lisp\"><pre>(message 'this)\n</pre></code>"
+  (should-render-as "<pre><code class=\"lisp\">(message 'this)\n</code></pre>"
                     "#+BEGIN_SRC lisp\n  (message 'this)\n#+END_SRC")
-  (should-render-as "<code class=\"sh\"><pre>&amp;&lt;&gt;\n</pre></code>"
+  (should-render-as "<pre><code class=\"sh\">&amp;&lt;&gt;\n</code></pre>"
                     "#+BEGIN_SRC sh\n  &<>\n#+END_SRC"))
 
 (ert-deftest ox-slimhtml-template ()

--- a/ox-slimhtml.el
+++ b/ox-slimhtml.el
@@ -213,7 +213,7 @@ INFO is a plist holding contextual information."
 CONTENTS is nil.  INFO is a plist holding contextual information."
   (let ((code (org-html-format-code example-block info)))
     (when code
-      (format "<code class=\"%s\"><pre>%s</pre></code>"
+      (format "<pre><code class=\"%s\">%s</code></pre>"
               (or (org-element-property :language example-block) "example")
               code))))
 
@@ -290,7 +290,7 @@ INFO is a plist holding contextual information."
   (let ((code (org-html-format-code src-block info))
         (language (org-element-property :language src-block)))
     (when code
-      (format "<code class=\"%s\"%s><pre>%s</pre></code>"
+      (format "<pre><code class=\"%s\"%s>%s</code></pre>"
               language (ox-slimhtml--attr src-block) code))))
 
 ;; body


### PR DESCRIPTION
Hello!

First of all, thank you for this great package! I use it daily and find very useful (I write in Org and have to bear with those clanky HTML editors on a certain publishing platform).

I believe that `<pre>` should wrap `<code>` when exporting code blocks, not vice versa.

1. It makes a bit more sense semantically, since `<pre>` is a block element, and `<code>` is an inline element.
1. W3C recommendation https://www.w3.org/TR/html50/grouping-content.html#the-pre-element
1. MDN docs suggest this too https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code#Notes

(btw, relevant thread https://twitter.com/freetonik/status/1075080034283610113)

Thanks.