### PR TITLE
Export quote blocks as blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ As a concrete example, the difference between the default exporter and `slimhtml
 ### blocks
 
 
+#### quotes
+
+    #+BEGIN_QUOTE                              # <blockquote><p>content</p></blockquote>
+    content
+    #+END_QUOTE
+
+
 #### examples
 
     #+BEGIN_EXAMPLE                            # content

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ As a concrete example, the difference between the default exporter and `slimhtml
 
 #### quotes
 
-    #+BEGIN_QUOTE                              # <blockquote><p>content</p></blockquote>
+    #+BEGIN_QUOTE                              # <blockquote>content</blockquote>
     content
     #+END_QUOTE
 

--- a/ox-slimhtml-tests.el
+++ b/ox-slimhtml-tests.el
@@ -119,6 +119,10 @@
   (should-render-as "<pre><code class=\"sh\">&amp;&lt;&gt;\n</code></pre>"
                     "#+BEGIN_SRC sh\n  &<>\n#+END_SRC"))
 
+(ert-deftest ox-slimhtml-quote-block ()
+  (should-render-as "<blockquote><p>this\n</p></blockquote>"
+                    "#+BEGIN_QUOTE\nthis\n#+END_QUOTE"))
+
 (ert-deftest ox-slimhtml-template ()
   (should (org-export-string-as "" 'slimhtml))
   (let ((expected-result

--- a/ox-slimhtml-tests.el
+++ b/ox-slimhtml-tests.el
@@ -120,7 +120,7 @@
                     "#+BEGIN_SRC sh\n  &<>\n#+END_SRC"))
 
 (ert-deftest ox-slimhtml-quote-block ()
-  (should-render-as "<blockquote><p>this\n</p></blockquote>"
+  (should-render-as "<blockquote>this\n</blockquote>"
                     "#+BEGIN_QUOTE\nthis\n#+END_QUOTE"))
 
 (ert-deftest ox-slimhtml-template ()

--- a/ox-slimhtml.el
+++ b/ox-slimhtml.el
@@ -307,7 +307,7 @@ INFO is a plist holding contextual information."
 CONTENTS is the text of a #+BEGIN_QUOTE...#+END_QUOTE block.
 INFO is a plist holding contextual information."
   (when contents
-    (format "<blockquote%s><p>%s</p></blockquote>"
+    (format "<blockquote%s>%s</blockquote>"
             (ox-slimhtml--attr quote-block) contents)))
 
 ;; body

--- a/ox-slimhtml.el
+++ b/ox-slimhtml.el
@@ -194,7 +194,8 @@ CONTENTS is the contents of the paragraph.
 INFO is a plist holding contextual information."
   (when contents
     (if (or (ox-slimhtml--immediate-child-of-p paragraph 'item)
-            (ox-slimhtml--immediate-child-of-p paragraph 'special-block))
+            (ox-slimhtml--immediate-child-of-p paragraph 'special-block)
+            (ox-slimhtml--immediate-child-of-p paragraph 'quote-block))
         contents
       (if (ox-slimhtml--has-immediate-child-of-p paragraph 'link)
           (format "<p>%s</p>" contents)
@@ -292,6 +293,22 @@ INFO is a plist holding contextual information."
     (when code
       (format "<pre><code class=\"%s\"%s>%s</code></pre>"
               language (ox-slimhtml--attr src-block) code))))
+
+;; quote block
+;; #+BEGIN_EXAMPLE
+;;   ,#+BEGIN_QUOTE                              # <blockquote>
+;;     quoted text                              # quoted text
+;;   ,#+END_QUOTE                                # </blockquote>
+;; #+END_EXAMPLE
+
+(defun ox-slimhtml-quote-block (quote-block contents info)
+  "Transcode QUOTE-BLOCK from Org to HTML.
+
+CONTENTS is the text of a #+BEGIN_QUOTE...#+END_QUOTE block.
+INFO is a plist holding contextual information."
+  (when contents
+    (format "<blockquote%s><p>%s</p></blockquote>"
+            (ox-slimhtml--attr quote-block) contents)))
 
 ;; body
 ;; #+BEGIN_EXAMPLE
@@ -487,6 +504,7 @@ Return output file name."
    (section . ox-slimhtml-section)
    (special-block . ox-slimhtml-special-block)
    (src-block . ox-slimhtml-src-block)
+   (quote-block . ox-slimhtml-quote-block)
    (template . ox-slimhtml-template)
    (verbatim . ox-slimhtml-verbatim))
  :menu-entry


### PR DESCRIPTION
Adds HTML export of quote blocks within `<blockquote>` tags. The quoted content itself remains within a `<p>` tag as this appears to be the correct practice even as far back as HTML 4.0 (per its DTD, `<blockquote>` may only contain block elements inside, _not_ free text as most people used).

Closes #5