### PR TITLE
Render non-fuzzy links without content correctly

### DIFF
--- a/ox-slimhtml-tests.el
+++ b/ox-slimhtml-tests.el
@@ -55,6 +55,10 @@
   (should-render-as "<p><em>link</em></p>"
                     "[[link]]")
 
+  "non-fuzzy links without content are rendered as the full link"
+  (should-render-as "<p><a href=\"https://example.com\">https://example.com</a></p>"
+                    "[[https://example.com]]")
+
   "renders fuzzy links as is"
   (should-render-as "<p><a href=\"link\">content</a></p>"
                     "[[link][content]]")

--- a/ox-slimhtml.el
+++ b/ox-slimhtml.el
@@ -135,18 +135,17 @@ Sections are child elements of org headlines;
 CONTENTS is the text of the link.
 INFO is a plist holding contextual information."
   (if (ox-slimhtml--immediate-child-of-p link 'link) (org-element-property :raw-link link)
-    (if (not contents) (format "<em>%s</em>" (org-element-property :path link))
       (let ((link-type (org-element-property :type link))
             (href (org-element-property :raw-link link))
             (attributes (if (ox-slimhtml--immediate-child-of-p link 'paragraph)
                             (ox-slimhtml--attr (org-export-get-parent link))
                           ""))
+            (path (or (org-element-property :path link) ""))
             (element "<a href=\"%s\"%s>%s</a>"))
         (cond ((string= "file" link-type)
                (let ((html-extension (or (plist-get info :html-extension) ""))
                      (use-abs-url (plist-get info :html-link-use-abs-url))
-                     (link-org-files-as-html (plist-get info :html-link-org-as-html))
-                     (path (or (org-element-property :path link) "")))
+                     (link-org-files-as-html (plist-get info :html-link-org-as-html)))
                  (format element
                          (concat (if (and use-abs-url (file-name-absolute-p path)) "file:" "")
                                  (if (and link-org-files-as-html (string= "org" (downcase (or (file-name-extension path) ""))))
@@ -155,8 +154,11 @@ INFO is a plist holding contextual information."
                                        (file-name-sans-extension path))
                                    path))
                          attributes contents)))
+              ((and (string= "fuzzy" link-type)
+                    (not contents))
+               (format "<em>%s</em>" path))
               (t
-               (format element href attributes contents)))))))
+               (format element href attributes (or contents href)))))))
 
 ;; plain lists
 ;; #+BEGIN_EXAMPLE


### PR DESCRIPTION
Hi!
First, thank you for making this package, it's really great!

Currently, proper links without contents, e.g. `[[https://example.com]]` don't render quite how you expect, #9 gives a full example. This adds an extra case when formatting links to handle the above case properly.

Fixes #9.
Thanks again~